### PR TITLE
chore: pass download format to binstall for cocogitto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install cocogitto to get the next version number
         shell: pwsh
         run: |
-          cargo binstall --no-confirm cocogitto
+          cargo binstall --no-confirm cocogitto --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ target }/{ bin }{ binary-ext }" --target x86_64-unknown-linux-musl --pkg-fmt tgz --bin cog --strategies crate-meta-data
 
       - name: Calculate next version
         shell: pwsh

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install cocogitto to get the next version number
         shell: pwsh
         run: |
-          cargo binstall --no-confirm cocogitto
+          cargo binstall --no-confirm cocogitto --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ target }/{ bin }{ binary-ext }" --target x86_64-unknown-linux-musl --pkg-fmt tgz --bin cog --strategies crate-meta-data
 
       - name: Check the commits
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install cocogitto to get the next version number
         shell: pwsh
         run: |
-          cargo binstall --no-confirm cocogitto
+          cargo binstall --no-confirm cocogitto --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ target }/{ bin }{ binary-ext }" --target x86_64-unknown-linux-musl --pkg-fmt tgz --bin cog --strategies crate-meta-data
 
       - name: Bump
         shell: pwsh

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install cocogitto to get the next version number
         shell: pwsh
         run: |
-          cargo binstall --no-confirm cocogitto
+          cargo binstall --no-confirm cocogitto --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ target }/{ bin }{ binary-ext }" --target x86_64-unknown-linux-musl --pkg-fmt tgz --bin cog --strategies crate-meta-data
 
       - name: Bump
         shell: pwsh


### PR DESCRIPTION
binstall iterates all possibilities until a match, and cocogitto's match is
low on that list. Problem is that github returns a 403s, resulting in downloading from sources
