### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,7 @@ jobs:
             --source-dir .
 
       - name: Upload coverage results (to Codecov.io)
-        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           disable_search: true
           disable_telem: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -33,7 +33,7 @@ jobs:
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Set up node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: package.json
           cache: pnpm


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.135.0**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust docker tag to v2**
- **chore(deps): update actions/setup-node action to v5**
- **fix: use semver version.**
- **chore(deps): update codecov/codecov-action action to v5.5.1**
